### PR TITLE
Local customisations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build.log
 docker-compose.yml
+local/*
+!local/*.dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,11 @@ RUN apt-get -y install sudo && \
     echo "ubuntu ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     usermod -a -G sudo ubuntu
 
+# Load custom .bashrc settings if available.
+USER ubuntu
+RUN echo 'LOCAL_BASHRC="$HOME/.local/bashrc"; test -f "${LOCAL_BASHRC}" && source "${LOCAL_BASHRC}"' >> ~/.bashrc
+USER root
+
 # Clean-up installation.
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y autoclean && \
     DEBIAN_FRONTEND=noninteractive apt-get -y autoremove

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ From the host server, add the web container IP address to the hosts file.
 sudo docker exec -it dockerdrupalphp70dev_drupalphp70devweb_1 su - ubuntu
 ```
 
+## Local customisations
+```bash
+# Customize scripts in local folders.
+cp local/bashrc.dist local/bashrc
+vim local/bashrc
+```
+
+
 # TODO
 
 - [XHProf](http://pecl.php.net/package/xhprof) - function-level hierarchical profiler.

--- a/local/bashrc.dist
+++ b/local/bashrc.dist
@@ -1,0 +1,16 @@
+find_git_branch() {
+  # Based on: https://github.com/jimeh/git-aware-prompt http://stackoverflow.com/a/13003854/170413
+  local branch
+  if branch=$(git rev-parse --abbrev-ref HEAD 2> /dev/null); then
+    if [[ "$branch" == "HEAD" ]]; then
+      branch='detached'
+    fi
+    git_branch="($branch)"
+  else
+    git_branch=""
+  fi
+  echo $git_branch;
+}
+
+
+PS1='\[\e]0;\u@\h: \w\a\]${debian_chroot:+($debian_chroot)}\u@\h:`find_git_branch`\w\$ '


### PR DESCRIPTION
### Scope

We want to supply infrastructure for a user to have room for local customisations.
### Implementation
- We ship a `local` directory, mounted into `/home/ubuntu/.local` by default.
- The `local` directory contains local convenience files.
- A sample `local/bashrc.dist` containing git-flow goodies is supplied.
- In a normal workflow, a user would `cp local/bashrc.dist local/bashrc` and customize the latter. The `.bashrc` file is already set to load `~/.local/bashrc` if existing.
- The `.gitignore` is set to ignore all files in `local`, except `*.dist`.
