### PR TITLE
Removed ast extension symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install python-sphinx python-pip d
 # XML needed by PHPCodeSniffer 2.3+
 # AST and SQLite needed by Phan
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install php-xml php-sqlite3 php-ast
-RUN ln -s /etc/php/mods-available/ast.ini /etc/php/7.0/cli/conf.d/20-ast.ini
 
 # Install XDebug 2.4.0
 RUN wget https://github.com/xdebug/xdebug/archive/XDEBUG_2_4_0.tar.gz && \


### PR DESCRIPTION
This line was removed, it caused failing build process because of the `file exists` error, I'm not sure but for newer version of ast it might not be necessary to symlink it, anyway I have tested it and extension itself worked.
